### PR TITLE
Make batch files work from paths containing spaces

### DIFF
--- a/Installer/_install.bat
+++ b/Installer/_install.bat
@@ -1,4 +1,4 @@
 echo Please run as admin
 
-@regsvr32 %~dp0wic_heic.dll
+@regsvr32 "%~dp0wic_heic.dll"
 pause

--- a/Installer/_uninstall.bat
+++ b/Installer/_uninstall.bat
@@ -1,4 +1,4 @@
 echo Please run as admin
 
-@regsvr32 /u %~dp0wic_heic.dll
+@regsvr32 /u "%~dp0wic_heic.dll"
 pause


### PR DESCRIPTION
If the path to the batch file contains spaces (like C:\\Program Files\\HEIC\\_uninstall.bat) then RegSrv32 will throw an error message: The module "c:\\Program" failed to load. etc.